### PR TITLE
Fix OpenAI token parameter

### DIFF
--- a/Source/GenerativeAISupport/Private/Models/OpenAI/GenOAIChat.cpp
+++ b/Source/GenerativeAISupport/Private/Models/OpenAI/GenOAIChat.cpp
@@ -58,7 +58,8 @@ void UGenOAIChat::MakeRequest(const FGenChatSettings& ChatSettings,
 
 	const TSharedPtr<FJsonObject> JsonPayload = MakeShareable(new FJsonObject());
 	JsonPayload->SetStringField(TEXT("model"), MutableSettings.Model);
-	JsonPayload->SetNumberField(TEXT("max_completion_tokens"), MutableSettings.MaxTokens);
+        // OpenAI uses the parameter name "max_tokens" for token limits
+        JsonPayload->SetNumberField(TEXT("max_tokens"), MutableSettings.MaxTokens);
 
 	TArray<TSharedPtr<FJsonValue>> MessagesArray;
 	for (const auto& [Role, Content] : MutableSettings.Messages)

--- a/Source/GenerativeAISupport/Private/Models/OpenAI/GenOAIStructuredOpService.cpp
+++ b/Source/GenerativeAISupport/Private/Models/OpenAI/GenOAIStructuredOpService.cpp
@@ -75,7 +75,8 @@ void UGenOAIStructuredOpService::MakeRequest(const FGenOAIStructuredChatSettings
 
     ResponseFormat->SetObjectField(TEXT("json_schema"), RootSchemaObject);
     JsonPayload->SetObjectField(TEXT("response_format"), ResponseFormat);
-    JsonPayload->SetNumberField(TEXT("max_completion_tokens"), StructuredChatSettings.ChatSettings.MaxTokens);
+    // Use the standard "max_tokens" parameter used by OpenAI
+    JsonPayload->SetNumberField(TEXT("max_tokens"), StructuredChatSettings.ChatSettings.MaxTokens);
     //set messages field, and append "Generate Response in JSON only." to the prompt
     TArray<TSharedPtr<FJsonValue>> MessagesArray;
     for (const FGenChatMessage& Message : StructuredChatSettings.ChatSettings.Messages)


### PR DESCRIPTION
## Summary
- fix OpenAI chat payload to use `max_tokens`
- update structured output requests accordingly

## Testing
- `git status --short`
