### PR TITLE
Add material node creation utilities

### DIFF
--- a/Content/Python/handlers/material_commands.py
+++ b/Content/Python/handlers/material_commands.py
@@ -1,0 +1,37 @@
+import json
+import unreal
+from typing import Dict, Any
+from utils import logging as log
+
+
+def handle_create_material_node(command: Dict[str, Any]) -> Dict[str, Any]:
+    """Create a material expression node on an existing material"""
+    try:
+        material_path = command.get("material_path")
+        node_type = command.get("node_type")
+        node_position = command.get("node_position", [0, 0])
+        node_properties = command.get("node_properties", {})
+
+        if not material_path or not node_type:
+            return {"success": False, "error": "Missing required parameters"}
+
+        props_json = json.dumps(node_properties)
+        result_json = unreal.GenMaterialUtils.add_material_node(
+            material_path, node_type, float(node_position[0]), float(node_position[1]), props_json
+        )
+        return json.loads(result_json)
+    except Exception as e:
+        log.log_error(f"Error creating material node: {str(e)}", include_traceback=True)
+        return {"success": False, "error": str(e)}
+
+
+def handle_get_material_nodes(command: Dict[str, Any]) -> Dict[str, Any]:
+    """Return list of all available material nodes and their editable properties"""
+    try:
+        json_str = unreal.GenMaterialUtils.get_all_material_nodes()
+        data = json.loads(json_str)
+        return {"success": True, "nodes": data}
+    except Exception as e:
+        log.log_error(f"Error fetching material nodes: {str(e)}", include_traceback=True)
+        return {"success": False, "error": str(e)}
+

--- a/Content/Python/unreal_socket_server.py
+++ b/Content/Python/unreal_socket_server.py
@@ -7,6 +7,7 @@ from typing import Dict, Any, Tuple, List, Optional
 
 # Import handlers
 from handlers import basic_commands, actor_commands, blueprint_commands, python_commands
+from handlers import material_commands
 from handlers import ui_commands
 from utils import logging as log
 
@@ -27,6 +28,8 @@ class CommandDispatcher:
             # Basic object commands
             "spawn": basic_commands.handle_spawn,
             "create_material": basic_commands.handle_create_material,
+            "create_material_node": material_commands.handle_create_material_node,
+            "get_material_nodes": material_commands.handle_get_material_nodes,
             "modify_object": actor_commands.handle_modify_object,
 
             # Blueprint commands
@@ -260,7 +263,7 @@ def initialize_server():
 
     log.log_info("Unreal Engine AI command server initialized successfully")
     log.log_info("Available commands:")
-    log.log_info("  - Basic: handshake, spawn, create_material, modify_object")
+    log.log_info("  - Basic: handshake, spawn, create_material, create_material_node, get_material_nodes, modify_object")
     log.log_info("  - Blueprint: create_blueprint, add_component, add_variable, add_function, add_node, connect_nodes, compile_blueprint, spawn_blueprint, add_nodes_bulk, connect_nodes_bulk")
 
 # Auto-start the server when this module is imported

--- a/Content/Python/utils/generate_material_nodes.py
+++ b/Content/Python/utils/generate_material_nodes.py
@@ -1,0 +1,8 @@
+import json
+import unreal
+
+out_path = unreal.Paths.combine([unreal.Paths.project_plugins_dir(), "GenerativeAISupport", "Resources", "MaterialNodes.json"])
+json_str = unreal.GenMaterialUtils.get_all_material_nodes()
+with open(out_path, "w", encoding="utf-8") as f:
+    f.write(json_str)
+print(f"Material node list written to {out_path}")

--- a/Docs/MaterialNodes.md
+++ b/Docs/MaterialNodes.md
@@ -1,0 +1,20 @@
+# Material Node Reference
+
+This file lists all available Unreal Engine material nodes and their editable properties as obtained from `UGenMaterialUtils::GetAllMaterialNodes()`.
+
+The included `Resources/MaterialNodes.json` is a placeholder. To generate a list for your engine version run the following in the Unreal Editor Python console:
+
+```python
+from plugins.GenerativeAISupport.Content.Python.utils import generate_material_nodes
+```
+
+This will update `Resources/MaterialNodes.json` with a JSON array of nodes. Each entry has the format:
+
+```json
+{
+  "class": "MaterialExpressionMultiply",
+  "properties": ["A", "B", "ConstA", "ConstB"]
+}
+```
+
+You can then use the MCP command `create_material_node` with these class names and property keys.

--- a/README.md
+++ b/README.md
@@ -578,7 +578,7 @@ python <your_project_directoy>/Plugins/GenerativeAISupport/Content/Python/mcp_se
 - Nodes fail to connect properly with MCP
 - No undo redo support for MCP
 - No streaming support for Deepseek reasoning model
-- No complex material generation support for the create material tool
+ - No complex material generation support for the create material tool *(basic material node creation is now available via the `create_material_node` MCP command. See `Docs/MaterialNodes.md` for details)*
 - Issues with running some llm generated valid python scripts
 - When LLM compiles a blueprint no proper error handling in its response
 - Issues spawning certain nodes, especially with getters and setters

--- a/Resources/MaterialNodes.json
+++ b/Resources/MaterialNodes.json
@@ -1,0 +1,5 @@
+{
+  "generated": false,
+  "note": "Run `python utils/generate_material_nodes.py` inside Unreal Editor to regenerate with real data.",
+  "nodes": []
+}

--- a/Source/GenerativeAISupportEditor/Private/MCP/GenMaterialUtils.cpp
+++ b/Source/GenerativeAISupportEditor/Private/MCP/GenMaterialUtils.cpp
@@ -1,0 +1,135 @@
+#include "MCP/GenMaterialUtils.h"
+#include "Materials/Material.h"
+#include "Materials/MaterialExpression.h"
+#include "MaterialEditingLibrary.h"
+#include "UObject/UObjectIterator.h"
+#include "UObject/ConstructorHelpers.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+
+FString UGenMaterialUtils::AddMaterialNode(const FString& MaterialPath, const FString& NodeClass, float NodeX, float NodeY, const FString& PropertiesJson)
+{
+    UMaterial* Material = LoadObject<UMaterial>(nullptr, *MaterialPath);
+    if (!Material)
+    {
+        return TEXT("{\"success\": false, \"error\": \"Material not found\"}");
+    }
+
+    UClass* ExpressionClass = FindObject<UClass>(ANY_PACKAGE, *NodeClass);
+    if (!ExpressionClass || !ExpressionClass->IsChildOf(UMaterialExpression::StaticClass()))
+    {
+        return TEXT("{\"success\": false, \"error\": \"Invalid node class\"}");
+    }
+
+    UMaterialExpression* Expression = Cast<UMaterialExpression>(UMaterialEditingLibrary::CreateMaterialExpression(Material, ExpressionClass, NodeX, NodeY));
+    if (!Expression)
+    {
+        return TEXT("{\"success\": false, \"error\": \"Failed to create node\"}");
+    }
+
+    if (!PropertiesJson.IsEmpty())
+    {
+        TSharedPtr<FJsonObject> JsonObj;
+        TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(PropertiesJson);
+        if (FJsonSerializer::Deserialize(Reader, JsonObj) && JsonObj.IsValid())
+        {
+            for (const auto& Pair : JsonObj->Values)
+            {
+                FProperty* Prop = ExpressionClass->FindPropertyByName(*Pair.Key);
+                if (!Prop) continue;
+                void* PropPtr = Prop->ContainerPtrToValuePtr<void>(Expression);
+                if (FNumericProperty* NumProp = CastField<FNumericProperty>(Prop))
+                {
+                    if (Pair.Value->Type == EJson::Number)
+                    {
+                        double Val = Pair.Value->AsNumber();
+                        if (NumProp->IsInteger())
+                            NumProp->SetIntPropertyValue(PropPtr, (int64)Val);
+                        else
+                            NumProp->SetFloatingPointPropertyValue(PropPtr, Val);
+                    }
+                }
+                else if (FBoolProperty* BoolProp = CastField<FBoolProperty>(Prop))
+                {
+                    if (Pair.Value->Type == EJson::Boolean)
+                        BoolProp->SetPropertyValue(PropPtr, Pair.Value->AsBool());
+                }
+                else if (FStrProperty* StrProp = CastField<FStrProperty>(Prop))
+                {
+                    if (Pair.Value->Type == EJson::String)
+                        StrProp->SetPropertyValue(PropPtr, Pair.Value->AsString());
+                }
+                else if (FStructProperty* StructProp = CastField<FStructProperty>(Prop))
+                {
+                    if (StructProp->Struct == TBaseStructure<FLinearColor>::Get() && Pair.Value->Type == EJson::Array)
+                    {
+                        const TArray<TSharedPtr<FJsonValue>>& Arr = Pair.Value->AsArray();
+                        if (Arr.Num() >= 3)
+                        {
+                            FLinearColor Color;
+                            Color.R = Arr[0]->AsNumber();
+                            Color.G = Arr[1]->AsNumber();
+                            Color.B = Arr[2]->AsNumber();
+                            Color.A = Arr.Num() > 3 ? Arr[3]->AsNumber() : 1.0f;
+                            *StructProp->ContainerPtrToValuePtr<FLinearColor>(Expression) = Color;
+                        }
+                    }
+                    else if (StructProp->Struct == TBaseStructure<FVector2D>::Get() && Pair.Value->Type == EJson::Array)
+                    {
+                        const TArray<TSharedPtr<FJsonValue>>& Arr = Pair.Value->AsArray();
+                        if (Arr.Num() >= 2)
+                        {
+                            FVector2D Vec;
+                            Vec.X = Arr[0]->AsNumber();
+                            Vec.Y = Arr[1]->AsNumber();
+                            *StructProp->ContainerPtrToValuePtr<FVector2D>(Expression) = Vec;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (!Expression->MaterialExpressionGuid.IsValid())
+    {
+        Expression->MaterialExpressionGuid = FGuid::NewGuid();
+    }
+
+    Material->PostEditChange();
+    UMaterialEditingLibrary::RecompileMaterial(Material);
+
+    return FString::Printf(TEXT("{\"success\": true, \"node_guid\": \"%s\"}"), *Expression->MaterialExpressionGuid.ToString());
+}
+
+FString UGenMaterialUtils::GetAllMaterialNodes()
+{
+    TArray<TSharedPtr<FJsonValue>> NodeArray;
+    for (TObjectIterator<UClass> It; It; ++It)
+    {
+        UClass* Cls = *It;
+        if (!Cls->IsChildOf(UMaterialExpression::StaticClass()) || Cls->HasAnyClassFlags(CLASS_Abstract))
+        {
+            continue;
+        }
+
+        TSharedPtr<FJsonObject> NodeObj = MakeShareable(new FJsonObject);
+        NodeObj->SetStringField(TEXT("class"), Cls->GetName());
+        TArray<TSharedPtr<FJsonValue>> Props;
+        for (TFieldIterator<FProperty> PropIt(Cls, EFieldIteratorFlags::IncludeSuper); PropIt; ++PropIt)
+        {
+            FProperty* Prop = *PropIt;
+            if (Prop->HasAnyPropertyFlags(CPF_Edit))
+            {
+                Props.Add(MakeShareable(new FJsonValueString(Prop->GetName())));
+            }
+        }
+        NodeObj->SetArrayField(TEXT("properties"), Props);
+        NodeArray.Add(MakeShareable(new FJsonValueObject(NodeObj)));
+    }
+
+    FString OutJson;
+    TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutJson);
+    FJsonSerializer::Serialize(NodeArray, Writer);
+    return OutJson;
+}
+

--- a/Source/GenerativeAISupportEditor/Public/MCP/GenMaterialUtils.h
+++ b/Source/GenerativeAISupportEditor/Public/MCP/GenMaterialUtils.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "GenMaterialUtils.generated.h"
+
+/** Utility functions for creating and querying material nodes via MCP */
+UCLASS()
+class GENERATIVEAISUPPORTEDITOR_API UGenMaterialUtils : public UBlueprintFunctionLibrary
+{
+    GENERATED_BODY()
+public:
+    /**
+     * Add a material expression node to a material.
+     * @param MaterialPath Path to the material asset e.g. "/Game/Materials/M_Test"
+     * @param NodeClass Name of the material expression class e.g. "MaterialExpressionMultiply"
+     * @param NodeX X position in the material graph
+     * @param NodeY Y position in the material graph
+     * @param PropertiesJson JSON object of editable property values
+     * @return JSON string with success flag and the created node GUID
+     */
+    UFUNCTION(BlueprintCallable, Category="Generative AI|Material Utils")
+    static FString AddMaterialNode(const FString& MaterialPath, const FString& NodeClass, float NodeX, float NodeY, const FString& PropertiesJson);
+
+    /**
+     * Get a list of all available material expression classes and their editable properties.
+     * @return JSON array of objects {"class":"MaterialExpressionAdd","properties":["A","B"]}
+     */
+    UFUNCTION(BlueprintCallable, Category="Generative AI|Material Utils")
+    static FString GetAllMaterialNodes();
+};
+


### PR DESCRIPTION
## Summary
- add `GenMaterialUtils` C++ class to create material nodes and list all available nodes
- expose new MCP commands `create_material_node` and `get_material_nodes`
- provide Python handlers and update server
- include script to generate material node list
- document material nodes reference
- note support in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`